### PR TITLE
feat: add i18n (pt-BR, es), Algolia search, and cross-promotion (#27)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+ALGOLIA_APP_ID=your_app_id
+ALGOLIA_API_KEY=your_search_api_key
+ALGOLIA_INDEX_NAME=python-from-zero-to-hero

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /.venv
 /venv
 
+# Environment variables
+.env
+
 # Docusaurus
 .docusaurus/
 build/

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -21,7 +21,12 @@ const config: Config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],
+    locales: ['en', 'pt-BR', 'es'],
+    localeConfigs: {
+      en: { label: 'English' },
+      'pt-BR': { label: 'Português (BR)' },
+      es: { label: 'Español' },
+    },
   },
 
   presets: [
@@ -56,6 +61,7 @@ const config: Config = {
       items: [
         {type: 'docSidebar', sidebarId: 'courseSidebar', position: 'left', label: 'Course'},
         {href: 'https://github.com/EmersonBraun/python-excercices', label: 'GitHub', position: 'right'},
+        {type: 'localeDropdown', position: 'right'},
       ],
     },
     footer: {
@@ -82,6 +88,12 @@ const config: Config = {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
       additionalLanguages: ['bash', 'json', 'yaml', 'sql', 'python'],
+    },
+    algolia: {
+      appId: process.env.ALGOLIA_APP_ID || 'placeholder',
+      apiKey: process.env.ALGOLIA_API_KEY || 'placeholder',
+      indexName: process.env.ALGOLIA_INDEX_NAME || 'python-from-zero-to-hero',
+      contextualSearch: true,
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -1,0 +1,110 @@
+{
+  "Home": {
+    "message": "Inicio",
+    "description": "Navbar home link label"
+  },
+  "Course": {
+    "message": "Curso",
+    "description": "Navbar course link label"
+  },
+  "GitHub": {
+    "message": "GitHub",
+    "description": "Navbar GitHub link label"
+  },
+  "Start Learning": {
+    "message": "Empezar a Aprender",
+    "description": "Hero CTA button"
+  },
+  "What is this course?": {
+    "message": "¿Qué es este curso?",
+    "description": "Homepage section heading"
+  },
+  "Python From Zero to Hero is a comprehensive, hands-on Python course that takes you from absolute beginner to advanced developer. Each module combines theory with interactive exercises you can run locally, plus real-world projects to build your portfolio.": {
+    "message": "Python de Cero a Héroe es un curso completo y práctico de Python que te lleva desde principiante absoluto hasta desarrollador avanzado. Cada módulo combina teoría con ejercicios interactivos que puedes ejecutar localmente, más proyectos del mundo real para construir tu portafolio.",
+    "description": "Homepage course description"
+  },
+  "Explore the Course": {
+    "message": "Explorar el Curso",
+    "description": "Homepage explore course button"
+  },
+  "What you will learn": {
+    "message": "Lo que aprenderás",
+    "description": "Homepage learn section heading"
+  },
+  "Python fundamentals from scratch": {
+    "message": "Fundamentos de Python desde cero",
+    "description": "Homepage learn list item"
+  },
+  "Functions, modules, and OOP": {
+    "message": "Funciones, módulos y POO",
+    "description": "Homepage learn list item"
+  },
+  "Decorators, generators, and async patterns": {
+    "message": "Decoradores, generadores y patrones asíncronos",
+    "description": "Homepage learn list item"
+  },
+  "Real-world projects and exercises": {
+    "message": "Proyectos y ejercicios del mundo real",
+    "description": "Homepage learn list item"
+  },
+  "Testing, debugging, and best practices": {
+    "message": "Pruebas, depuración y mejores prácticas",
+    "description": "Homepage learn list item"
+  },
+  "Design patterns and performance optimization": {
+    "message": "Patrones de diseño y optimización del rendimiento",
+    "description": "Homepage learn list item"
+  },
+  "Help Improve This Course": {
+    "message": "Ayuda a Mejorar Este Curso",
+    "description": "Homepage contribute section heading"
+  },
+  "This project thrives on community contributions. Whether you are learning Python or are an experienced developer, your insights are valuable!": {
+    "message": "Este proyecto prospera con las contribuciones de la comunidad. Ya seas un aprendiz de Python o un desarrollador experimentado, ¡tus ideas son valiosas!",
+    "description": "Homepage contribute description"
+  },
+  "Contribute to the Project": {
+    "message": "Contribuir al Proyecto",
+    "description": "Homepage contribute button"
+  },
+  "More Resources": {
+    "message": "Más Recursos",
+    "description": "Homepage more resources section heading"
+  },
+  "Docs": {
+    "message": "Documentación",
+    "description": "Footer docs section title"
+  },
+  "Connect": {
+    "message": "Conectar",
+    "description": "Footer connect section title"
+  },
+  "How to use these exercises": {
+    "message": "Cómo usar estos ejercicios",
+    "description": "Sidebar label for usage guide"
+  },
+  "Beginner": {
+    "message": "Principiante",
+    "description": "Sidebar category label"
+  },
+  "Intermediate": {
+    "message": "Intermedio",
+    "description": "Sidebar category label"
+  },
+  "Advanced": {
+    "message": "Avanzado",
+    "description": "Sidebar category label"
+  },
+  "Get the Ebook": {
+    "message": "Obtener el Ebook",
+    "description": "Ebook CTA button label"
+  },
+  "View JS Course": {
+    "message": "Ver Curso de JS",
+    "description": "JS course card link label"
+  },
+  "View AWS Cheatsheet": {
+    "message": "Ver Cheatsheet de AWS",
+    "description": "AWS cheatsheet card link label"
+  }
+}

--- a/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,30 @@
+{
+  "sidebar.courseSidebar.category.Beginner": {
+    "message": "Principiante",
+    "description": "The label for category Beginner in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Intermediate": {
+    "message": "Intermedio",
+    "description": "The label for category Intermediate in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Advanced": {
+    "message": "Avanzado",
+    "description": "The label for category Advanced in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Foundations": {
+    "message": "Fundamentos",
+    "description": "The label for category Foundations in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Functions": {
+    "message": "Funciones",
+    "description": "The label for category Functions in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Object-Oriented Programming": {
+    "message": "Programación Orientada a Objetos",
+    "description": "The label for category OOP in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Practical Projects": {
+    "message": "Proyectos Prácticos",
+    "description": "The label for category Practical Projects in sidebar courseSidebar"
+  }
+}

--- a/i18n/pt-BR/code.json
+++ b/i18n/pt-BR/code.json
@@ -1,0 +1,110 @@
+{
+  "Home": {
+    "message": "Início",
+    "description": "Navbar home link label"
+  },
+  "Course": {
+    "message": "Curso",
+    "description": "Navbar course link label"
+  },
+  "GitHub": {
+    "message": "GitHub",
+    "description": "Navbar GitHub link label"
+  },
+  "Start Learning": {
+    "message": "Começar a Aprender",
+    "description": "Hero CTA button"
+  },
+  "What is this course?": {
+    "message": "O que é este curso?",
+    "description": "Homepage section heading"
+  },
+  "Python From Zero to Hero is a comprehensive, hands-on Python course that takes you from absolute beginner to advanced developer. Each module combines theory with interactive exercises you can run locally, plus real-world projects to build your portfolio.": {
+    "message": "Python do Zero ao Herói é um curso completo e prático de Python que leva você de iniciante absoluto a desenvolvedor avançado. Cada módulo combina teoria com exercícios interativos que você pode executar localmente, além de projetos reais para construir seu portfólio.",
+    "description": "Homepage course description"
+  },
+  "Explore the Course": {
+    "message": "Explorar o Curso",
+    "description": "Homepage explore course button"
+  },
+  "What you will learn": {
+    "message": "O que você vai aprender",
+    "description": "Homepage learn section heading"
+  },
+  "Python fundamentals from scratch": {
+    "message": "Fundamentos de Python do zero",
+    "description": "Homepage learn list item"
+  },
+  "Functions, modules, and OOP": {
+    "message": "Funções, módulos e POO",
+    "description": "Homepage learn list item"
+  },
+  "Decorators, generators, and async patterns": {
+    "message": "Decorators, generators e padrões assíncronos",
+    "description": "Homepage learn list item"
+  },
+  "Real-world projects and exercises": {
+    "message": "Projetos e exercícios do mundo real",
+    "description": "Homepage learn list item"
+  },
+  "Testing, debugging, and best practices": {
+    "message": "Testes, depuração e boas práticas",
+    "description": "Homepage learn list item"
+  },
+  "Design patterns and performance optimization": {
+    "message": "Padrões de projeto e otimização de desempenho",
+    "description": "Homepage learn list item"
+  },
+  "Help Improve This Course": {
+    "message": "Ajude a Melhorar Este Curso",
+    "description": "Homepage contribute section heading"
+  },
+  "This project thrives on community contributions. Whether you are learning Python or are an experienced developer, your insights are valuable!": {
+    "message": "Este projeto prospera com contribuições da comunidade. Seja você um aprendiz de Python ou um desenvolvedor experiente, seus insights são valiosos!",
+    "description": "Homepage contribute description"
+  },
+  "Contribute to the Project": {
+    "message": "Contribuir com o Projeto",
+    "description": "Homepage contribute button"
+  },
+  "More Resources": {
+    "message": "Mais Recursos",
+    "description": "Homepage more resources section heading"
+  },
+  "Docs": {
+    "message": "Documentação",
+    "description": "Footer docs section title"
+  },
+  "Connect": {
+    "message": "Conectar",
+    "description": "Footer connect section title"
+  },
+  "How to use these exercises": {
+    "message": "Como usar estes exercícios",
+    "description": "Sidebar label for usage guide"
+  },
+  "Beginner": {
+    "message": "Iniciante",
+    "description": "Sidebar category label"
+  },
+  "Intermediate": {
+    "message": "Intermediário",
+    "description": "Sidebar category label"
+  },
+  "Advanced": {
+    "message": "Avançado",
+    "description": "Sidebar category label"
+  },
+  "Get the Ebook": {
+    "message": "Obter o Ebook",
+    "description": "Ebook CTA button label"
+  },
+  "View JS Course": {
+    "message": "Ver Curso de JS",
+    "description": "JS course card link label"
+  },
+  "View AWS Cheatsheet": {
+    "message": "Ver Cheatsheet AWS",
+    "description": "AWS cheatsheet card link label"
+  }
+}

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,30 @@
+{
+  "sidebar.courseSidebar.category.Beginner": {
+    "message": "Iniciante",
+    "description": "The label for category Beginner in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Intermediate": {
+    "message": "Intermediário",
+    "description": "The label for category Intermediate in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Advanced": {
+    "message": "Avançado",
+    "description": "The label for category Advanced in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Foundations": {
+    "message": "Fundamentos",
+    "description": "The label for category Foundations in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Functions": {
+    "message": "Funções",
+    "description": "The label for category Functions in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Object-Oriented Programming": {
+    "message": "Programação Orientada a Objetos",
+    "description": "The label for category OOP in sidebar courseSidebar"
+  },
+  "sidebar.courseSidebar.category.Practical Projects": {
+    "message": "Projetos Práticos",
+    "description": "The label for category Practical Projects in sidebar courseSidebar"
+  }
+}

--- a/src/components/AwsCheatsheetCard/index.tsx
+++ b/src/components/AwsCheatsheetCard/index.tsx
@@ -1,0 +1,28 @@
+import Link from '@docusaurus/Link';
+import {type ReactElement} from 'react';
+
+import styles from './styles.module.css';
+
+export default function AwsCheatsheetCard(): ReactElement {
+  return (
+    <div className={styles.card}>
+      <div className={styles.header}>
+        <span className={styles.icon} aria-hidden="true">
+          AWS
+        </span>
+        <h3 className={styles.title}>AWS Cheatsheet</h3>
+      </div>
+      <p className={styles.description}>
+        Quick-reference guide for the most important AWS services, CLI commands,
+        and cloud architecture patterns. Bookmark it, use it daily.
+      </p>
+      <Link
+        className="button button--secondary button--sm"
+        href="https://emersonbraun.github.io/aws-cheatsheet/"
+        target="_blank"
+        rel="noopener noreferrer">
+        View AWS Cheatsheet →
+      </Link>
+    </div>
+  );
+}

--- a/src/components/AwsCheatsheetCard/styles.module.css
+++ b/src/components/AwsCheatsheetCard/styles.module.css
@@ -1,0 +1,50 @@
+.card {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  background: var(--ifm-card-background-color, var(--ifm-background-surface-color));
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: 100%;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: #ff9900;
+  color: #fff;
+  font-weight: 900;
+  font-size: 0.65rem;
+  border-radius: 6px;
+  flex-shrink: 0;
+  letter-spacing: -0.5px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.description {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ifm-color-content-secondary);
+  flex: 1;
+}

--- a/src/components/EbookCta/index.tsx
+++ b/src/components/EbookCta/index.tsx
@@ -1,0 +1,28 @@
+import Link from '@docusaurus/Link';
+import {type ReactElement} from 'react';
+
+import styles from './styles.module.css';
+
+export default function EbookCta(): ReactElement {
+  return (
+    <div className={styles.banner}>
+      <div className={styles.iconWrapper} aria-hidden="true">
+        📘
+      </div>
+      <div className={styles.content}>
+        <h3 className={styles.title}>Cracking the Technical Interview</h3>
+        <p className={styles.description}>
+          Ace your next tech interview with proven strategies, real questions, and
+          expert tips. Get the ebook and land the job you deserve.
+        </p>
+      </div>
+      <Link
+        className="button button--primary"
+        href="https://ebook.emersonbraun.dev"
+        target="_blank"
+        rel="noopener noreferrer">
+        Get the Ebook
+      </Link>
+    </div>
+  );
+}

--- a/src/components/EbookCta/styles.module.css
+++ b/src/components/EbookCta/styles.module.css
@@ -1,0 +1,45 @@
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  background: var(--ifm-color-primary-lightest, #e8f4ff);
+  border: 1px solid var(--ifm-color-primary-light, #b3d9ff);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  margin: 1rem 0;
+  flex-wrap: wrap;
+}
+
+[data-theme='dark'] .banner {
+  background: var(--ifm-color-primary-darkest, #002b4d);
+  border-color: var(--ifm-color-primary-dark, #004080);
+}
+
+.iconWrapper {
+  font-size: 2.5rem;
+  flex-shrink: 0;
+}
+
+.content {
+  flex: 1;
+  min-width: 200px;
+}
+
+.title {
+  margin: 0 0 0.25rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ifm-color-content-secondary);
+}
+
+@media (max-width: 480px) {
+  .banner {
+    flex-direction: column;
+    text-align: center;
+  }
+}

--- a/src/components/JsCourseCard/index.tsx
+++ b/src/components/JsCourseCard/index.tsx
@@ -1,0 +1,28 @@
+import Link from '@docusaurus/Link';
+import {type ReactElement} from 'react';
+
+import styles from './styles.module.css';
+
+export default function JsCourseCard(): ReactElement {
+  return (
+    <div className={styles.card}>
+      <div className={styles.header}>
+        <span className={styles.icon} aria-hidden="true">
+          JS
+        </span>
+        <h3 className={styles.title}>JavaScript From Zero to Hero</h3>
+      </div>
+      <p className={styles.description}>
+        Learn JavaScript from the ground up — variables, DOM, async/await, and
+        modern ES2024+ features. Companion course to your Python journey.
+      </p>
+      <Link
+        className="button button--secondary button--sm"
+        href="https://emersonbraun.github.io/js-from-zero-to-hero/"
+        target="_blank"
+        rel="noopener noreferrer">
+        View JS Course →
+      </Link>
+    </div>
+  );
+}

--- a/src/components/JsCourseCard/styles.module.css
+++ b/src/components/JsCourseCard/styles.module.css
@@ -1,0 +1,50 @@
+.card {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  background: var(--ifm-card-background-color, var(--ifm-background-surface-color));
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: 100%;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: #f7df1e;
+  color: #000;
+  font-weight: 900;
+  font-size: 0.85rem;
+  border-radius: 6px;
+  flex-shrink: 0;
+  letter-spacing: -0.5px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.description {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ifm-color-content-secondary);
+  flex: 1;
+}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -106,6 +106,39 @@
   font-size: 1.2em;
 }
 
+.moreResources {
+  padding: 3rem 0 5rem;
+  background-color: var(--ifm-background-surface-color);
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.moreResources h2 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--ifm-color-primary) 0%, var(--ifm-color-primary-darker) 100%);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  display: inline-block;
+}
+
+.cardsRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.cardCol {
+  display: flex;
+}
+
+@media (max-width: 640px) {
+  .cardsRow {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Responsive adjustments */
 @media (max-width: 996px) {
   .heroBanner {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,9 @@ import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import {type ReactElement} from 'react';
 
+import AwsCheatsheetCard from '../components/AwsCheatsheetCard';
+import EbookCta from '../components/EbookCta';
+import JsCourseCard from '../components/JsCourseCard';
 import styles from './index.module.css';
 
 function HomepageHeader() {
@@ -75,6 +78,25 @@ export default function Home(): ReactElement {
                       href="https://github.com/EmersonBraun/python-excercices">
                       Contribute to the Project
                     </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.moreResources}>
+          <div className="container">
+            <div className="row">
+              <div className="col col--8 col--offset-2">
+                <h2 className="text--center" style={{marginBottom: '1.5rem'}}>More Resources</h2>
+                <EbookCta />
+                <div className={styles.cardsRow}>
+                  <div className={styles.cardCol}>
+                    <JsCourseCard />
+                  </div>
+                  <div className={styles.cardCol}>
+                    <AwsCheatsheetCard />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## What
- **i18n**: Re-enabled pt-BR and es locales with 27 translated UI strings each, locale dropdown in navbar, sidebar label translations
- **Algolia Search**: Configured with env vars (graceful fallback when not set), .env.example documented
- **Cross-promotion**: EbookCta banner, JS Course card, AWS Cheatsheet card — all on homepage "More Resources" section

## Why
Closes #27
Part of #19

## Checklist
- [x] Language switcher in navbar (en / pt-BR / es)
- [x] UI strings translated for both locales
- [x] Sidebar labels translated
- [x] Algolia search configured with env vars
- [x] .env.example created
- [x] EbookCta, JsCourseCard, AwsCheatsheetCard components
- [x] Homepage "More Resources" section
- [x] Build passes for all 3 locales